### PR TITLE
Fix path/url and trailing slashes

### DIFF
--- a/font-awesome/font-awesome.php
+++ b/font-awesome/font-awesome.php
@@ -13,16 +13,18 @@
 
 defined( 'WPINC' ) || die;
 
+define( 'FONTAWESOME_DIR_PATH', plugin_dir_path( __FILE__ ) );
+define( 'FONTAWESOME_DIR_URL', plugin_dir_url( __FILE__ ) );
 register_activation_hook( __FILE__, function(){
-  require_once plugin_dir_path( __FILE__ ) . 'includes/class-font-awesome-activator.php';
+  require_once FONTAWESOME_DIR_PATH . 'includes/class-font-awesome-activator.php';
   FontAwesome_Activator::activate();
 });
 
 register_deactivation_hook( __FILE__, function(){
-  require_once plugin_dir_path( __FILE__ ) . 'includes/class-font-awesome-deactivator.php';
+  require_once FONTAWESOME_DIR_PATH . 'includes/class-font-awesome-deactivator.php';
   FontAwesome_Deactivator::deactivate();
 });
 
-require_once plugin_dir_path( __FILE__ ) . 'includes/class-font-awesome.php';
+require_once FONTAWESOME_DIR_PATH . 'includes/class-font-awesome.php';
 
 FontAwesome()->run();

--- a/font-awesome/includes/class-font-awesome-release-provider.php
+++ b/font-awesome/includes/class-font-awesome-release-provider.php
@@ -1,6 +1,6 @@
 <?php
-require_once( dirname(plugin_dir_path(__FILE__)) . '/vendor/autoload.php');
-require_once( dirname(plugin_dir_path(__FILE__)) . '/includes/class-font-awesome-resource.php');
+require_once( FONTAWESOME_DIR_PATH . 'vendor/autoload.php');
+require_once( FONTAWESOME_DIR_PATH . 'includes/class-font-awesome-resource.php');
 
 use Composer\Semver\Semver;
 
@@ -28,7 +28,7 @@ if (! class_exists('FontAwesomeReleaseProvider') ) :
     private function __construct() { /* noop */ }
 
     private function load_releases(){
-      $files = glob( trailingslashit(dirname(plugin_dir_path(__FILE__))) . 'releases/release*.yml' );
+      $files = glob( trailingslashit(FONTAWESOME_DIR_PATH) . 'releases/release*.yml' );
       $this->_releases = array();
       foreach($files as $file){
         $basename = basename($file);

--- a/font-awesome/includes/class-font-awesome.php
+++ b/font-awesome/includes/class-font-awesome.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once( dirname(plugin_dir_path(__FILE__)) . '/vendor/autoload.php');
-require_once( dirname(plugin_dir_path(__FILE__)) . '/includes/class-font-awesome-release-provider.php');
-require_once( dirname(plugin_dir_path(__FILE__)) . '/includes/class-font-awesome-resource.php');
+require_once( FONTAWESOME_DIR_PATH . 'vendor/autoload.php');
+require_once( FONTAWESOME_DIR_PATH . 'includes/class-font-awesome-release-provider.php');
+require_once( FONTAWESOME_DIR_PATH . 'includes/class-font-awesome-resource.php');
 use Composer\Semver\Semver;
 
 if (! class_exists('FontAwesome') ) :
@@ -119,8 +119,8 @@ class FontAwesome {
   private function initialize_admin(){
     add_action('admin_enqueue_scripts', function(){
       $this->detect_unregistered_clients();
-      wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'admin/css/font-awesome-admin.css', array(), $this->version, 'all' );
-      wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'admin/js/font-awesome-admin.js', array('jquery'), $this->version );
+      wp_enqueue_style( $this->plugin_name, FONTAWESOME_DIR_URL . 'admin/css/font-awesome-admin.css', array(), $this->version, 'all' );
+      wp_enqueue_script( $this->plugin_name, FONTAWESOME_DIR_URL . 'admin/js/font-awesome-admin.js', array('jquery'), $this->version );
     });
 
     add_action('admin_menu', function(){
@@ -403,7 +403,7 @@ class FontAwesome {
   }
 
   public function create_admin_page(){
-    include_once( dirname(plugin_dir_path(__FILE__)) . '/admin/views/main.php' );
+    include_once( FONTAWESOME_DIR_PATH . 'admin/views/main.php' );
   }
 
   /**


### PR DESCRIPTION
In admin release 0.0.1 shows 404, because plugin_dir_url(__FILE__) contains `includes` folder. dirname from plugin_dir_url will help, however for better performance I have cached all the dir_url and dir_path to single define.