### PR TITLE
Avoid HTML output when detecting unregistered clients in config controller

### DIFF
--- a/includes/class-fontawesome-config-controller.php
+++ b/includes/class-fontawesome-config-controller.php
@@ -83,7 +83,9 @@ if ( ! class_exists( 'FortAwesome\FontAwesome_Config_Controller' ) ) :
 			$locked_load_spec = isset( $options['lockedLoadSpec'] ) ? $options['lockedLoadSpec'] : false;
 
 			/**
-			 * Calling wp_head() is required to trigger the 'wp_enqueue_scripts' action and detection of unregistered clients.
+			 * Calling wp_enqueue_scripts() is required to trigger the 'wp_enqueue_scripts' action that is the
+			 * conventional time in the WordPress lifecycle when plugins or themes would enqueue scripts or styles.
+			 * We also have to explicitly run the detection function.
 			 * Note that this can only possibly detect those clients who enqueue their styles or scripts within the context
 			 * of the controller action that invokes this function.
 			 * It's possible than some unregistered client enqueues a style or script in some other circumstance. We
@@ -96,7 +98,8 @@ if ( ! class_exists( 'FortAwesome\FontAwesome_Config_Controller' ) ) :
 			 * which is detected on the same page load for which FontAwesome::unregistered_clients() is queried.
 			 */
 			ob_start();
-			wp_head();
+			wp_enqueue_scripts();
+			$fa->detect_unregistered_clients();
 			ob_end_clean();
 
 			return array(

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1544,11 +1544,14 @@ EOT;
 			);
 		}
 
-		// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		/**
+		 * Detects unregistered clients, which can be retrieved with {@see FontAwesome::unregistered_clients()}.
+		 * For internal use only. Not part of this plugin's public API.
+		 *
+		 * @internal
 		 * @ignore
 		 */
-		protected function detect_unregistered_clients() {
+		public function detect_unregistered_clients() {
 			$wp_styles  = wp_styles();
 			$wp_scripts = wp_scripts();
 

--- a/integrations/plugins/plugin-gamma/plugin-gamma.php
+++ b/integrations/plugins/plugin-gamma/plugin-gamma.php
@@ -15,6 +15,8 @@ define( 'GAMMA_PLUGIN_VERSION', '0.0.1' );
 define( 'GAMMA_PLUGIN_LOG_PREFIX', 'gamma-plugin' );
 
 add_action('wp_enqueue_scripts', function(){
+	print "This rogue output from " . GAMMA_PLUGIN_LOG_PREFIX . " should not be returned by our config controller. If it does, it will break the admin client.";
+
   wp_enqueue_style(
     'GAMMA_PLUGIN_LOG_PREFIX',
     'https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.css',


### PR DESCRIPTION
This change makes it less susceptible to allowing HTML template
content emitted by other modules who have hooks running on the
wp_head action.

By convention, HTML content should never be emitted from
wp_enqueue_scripts hooks. Even if some module does, we still have
the output buffering capture to block it from being included
in the controller's response.