### PR TITLE
Fix function exists check on font_awesome_handle_fatal_error

### DIFF
--- a/font-awesome.php
+++ b/font-awesome.php
@@ -18,7 +18,7 @@ use \Exception, \Error;
 
 defined( 'WPINC' ) || die;
 
-if ( ! function_exists( 'font_awesome_handle_fatal_error' ) ) {
+if ( ! function_exists( __NAMESPACE__ . '\font_awesome_handle_fatal_error' ) ) {
 	/**
 	 * Handle fatal errors
 	 *


### PR DESCRIPTION
While working on a theme that includes this plugin through Composer, I encountered this error if the Font Awesome plugin itself is activated on WordPress as well:
```
wordpress_1   | [Sat Jan 18 17:51:17.746177 2020] [php7:error] [pid 1607] [client 172.25.0.1:58124] PHP Fatal error:  Cannot redeclare FortAwesome\\font_awesome_handle_fatal_error() (previously declared in /var/www/html/wp-content/plugins/font-awesome/font-awesome.php:27) in /var/www/html/wp-content/themes/kramerc/vendor/fortawesome/wordpress-fontawesome/font-awesome.php on line 27, referer: http://alki:8000/wp-admin/customize.php
```

The function exists check for `font_awesome_handle_fatal_error` doesn't factor in the namespace. Adding the namespace prefix to the `function_exists` call solves the problem.

---

For reference, I am using the ["Composer Dependency" option as specified in the readme](https://github.com/FortAwesome/wordpress-fontawesome/blob/11f110636f7617f4e481ce706cb26295f9fe46a1/README.md#how-to-ship-your-theme-or-plugin-to-work-with-font-awesome), although with slight adjustments given this plugin hasn't been published to Packagist yet. I have this plugin included in my theme with this added to composer.json:
```json
"repositories": [
    {
        "type": "github",
        "url": "https://github.com/FortAwesome/wordpress-fontawesome"
    }
],
"require": {
    "fortawesome/wordpress-fontawesome": "4.0.0-rc13"
}
```
And this require statement inside the theme's functions.php:
```php
require_once trailingslashit(__DIR__) . 'vendor/fortawesome/wordpress-fontawesome/font-awesome.php';
```