### PR TITLE
Add a fake kit script to theme alpha to test conflict detection

### DIFF
--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -178,7 +178,7 @@ class FontAwesome {
 	 * @ignore
 	 * @internal
 	 */
-	const CONFLICT_DETECTOR_SOURCE = 'https://use.fontawesome.com/releases/v5.12.1/js/conflict-detection.js';
+	const CONFLICT_DETECTOR_SOURCE = 'https://use.fontawesome.com/releases/v5.15.1/js/conflict-detection.js';
 
 	/**
 	 * The custom data attribute added to script, link, and style elements enqueued

--- a/integrations/themes/theme-alpha/fake-kit.js
+++ b/integrations/themes/theme-alpha/fake-kit.js
@@ -1,0 +1,3 @@
+// This should be enough for this script to be recognized
+// by the conflict detection scanner as a Font Awesome Kit.
+window.FontAwesomeKitConfig = {}

--- a/integrations/themes/theme-alpha/functions.php
+++ b/integrations/themes/theme-alpha/functions.php
@@ -19,6 +19,13 @@ add_action( 'wp_enqueue_scripts', function (){
       array( $parent_style ),
       wp_get_theme()->get('Version')
   );
+
+  wp_enqueue_script( 'theme-alpha-fake-kit',
+	  get_stylesheet_directory_uri() . '/fake-kit.js',
+	  [], // no deps
+	  null, // don't add version string
+	  false // don't put it in the footer
+  );
 });
 
 add_action('after_switch_theme', function(){


### PR DESCRIPTION
- [x] Add an integration test for the conflict detection scanner to detect a conflict kit loader script.

- [x] Release new version of Font Awesome with enhanced conflict-detection.js.

- [x] Once released, update the [URL for the conflict-detection.js](https://github.com/FortAwesome/wordpress-fontawesome/blob/de4245725420da3345d03543ea5cbea8998e2563/includes/class-fontawesome.php#L181) version loaded by this plugin.