### PR TITLE
Release metadata loading optimization

### DIFF
--- a/bin/configure-debugging
+++ b/bin/configure-debugging
@@ -4,18 +4,22 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/../.env
 source $DIR/.common.bash
 
+wp_cli() {
+  $DOCKER exec -it -e "WP_CLI_CACHE_DIR=${WP_CLI_CACHE_DIR}" -e "COLUMNS=`tput cols`" -e "LINES=`tput lines`" -e "TERM=xterm-256color" -w /var/www/html -u root:www-data $WP_CONTAINER wp --allow-root $@
+}
+
 echo "Adding WordPress debug configuration..."
-$DIR/wp -c ${WP_CONTAINER} config set WP_DEBUG true \
-&& $DIR/wp -c ${WP_CONTAINER} config set WP_DEBUG_LOG true \
-&& $DIR/wp -c ${WP_CONTAINER} config set WP_DEBUG_DISPLAY false \
-&& $DIR/wp -c ${WP_CONTAINER} config set SAVEQUERIES true \
-&& $DIR/wp -c ${WP_CONTAINER} plugin install debug-bar \
-&& $DIR/wp -c ${WP_CONTAINER} plugin install debug-bar-console \
-&& $DIR/wp -c ${WP_CONTAINER} plugin install debug-bar-constants \
-&& $DIR/wp -c ${WP_CONTAINER} plugin install debug-bar-actions-and-filters-addon \
-&& $DIR/wp -c ${WP_CONTAINER} plugin install debug-bar-transients \
-&& $DIR/wp -c ${WP_CONTAINER} plugin install debug-bar-list-dependencies \
-&& $DIR/wp -c ${WP_CONTAINER} plugin install debug-bar-remote-requests
+wp_cli config set WP_DEBUG true \
+&& wp_cli config set WP_DEBUG_LOG true \
+&& wp_cli config set WP_DEBUG_DISPLAY false \
+&& wp_cli config set SAVEQUERIES true \
+&& wp_cli plugin install debug-bar \
+&& wp_cli plugin install debug-bar-console \
+&& wp_cli plugin install debug-bar-constants \
+&& wp_cli plugin install debug-bar-actions-and-filters-addon \
+&& wp_cli plugin install debug-bar-transients \
+&& wp_cli plugin install debug-bar-list-dependencies \
+&& wp_cli plugin install debug-bar-remote-requests
 
 if [ "$?" == "0" ]; then
   echo "ok."

--- a/includes/class-fontawesome-deactivator.php
+++ b/includes/class-fontawesome-deactivator.php
@@ -17,6 +17,7 @@ class FontAwesome_Deactivator {
 	 */
 	public static function deactivate() {
 		delete_site_transient( FontAwesome_Release_Provider::RELEASES_TRANSIENT );
+		delete_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
 		delete_transient( FontAwesome::V3DEPRECATION_TRANSIENT );
 	}
 

--- a/includes/class-fontawesome-release-provider.php
+++ b/includes/class-fontawesome-release-provider.php
@@ -45,7 +45,7 @@ class FontAwesome_Release_Provider {
 	 *
 	 * @ignore
 	 */
-	const RELEASES_TRANSIENT_EXPIRY = 0;
+	const RELEASES_TRANSIENT_EXPIRY = 31536000; // a year.
 
 	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/**

--- a/includes/class-fontawesome-release-provider.php
+++ b/includes/class-fontawesome-release-provider.php
@@ -380,10 +380,10 @@ EOD;
 		if ( $last_used_transient ) {
 			// For simplicity, we're require that it's exactly what we're looking for, else we'll re-build and overwrite it.
 			if (
-				$version == $last_used_transient['version']
-				&& $flags['use_pro'] == $last_used_transient['use_pro']
-				&& $flags['use_svg'] == $last_used_transient['use_svg']
-				&& $flags['use_shim'] == $last_used_transient['use_shim']
+				$version === $last_used_transient['version']
+				&& $flags['use_pro'] === $last_used_transient['use_pro']
+				&& $flags['use_svg'] === $last_used_transient['use_svg']
+				&& $flags['use_shim'] === $last_used_transient['use_shim']
 				&& is_array( $last_used_transient['resources'] )
 			) {
 				return new FontAwesome_ResourceCollection( $version, $last_used_transient['resources'] );

--- a/includes/class-fontawesome-release-provider.php
+++ b/includes/class-fontawesome-release-provider.php
@@ -45,7 +45,7 @@ class FontAwesome_Release_Provider {
 	 *
 	 * @ignore
 	 */
-	const RELEASES_TRANSIENT_EXPIRY = 31536000; // a year.
+	const RELEASES_TRANSIENT_EXPIRY = YEAR_IN_SECONDS;
 
 	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/**

--- a/includes/class-fontawesome-release-provider.php
+++ b/includes/class-fontawesome-release-provider.php
@@ -41,11 +41,30 @@ class FontAwesome_Release_Provider {
 	const RELEASES_TRANSIENT = 'font-awesome-releases';
 
 	/**
+	 * Name of the transient that stores the cache of the last used Font Awesome
+	 * release so we won't load all of the releases metadata on each page load.
+	 *
+	 * @since 4.0.0-rc4
+	 * @ignore
+	 * @internal
+	 */
+	const LAST_USED_RELEASE_TRANSIENT  = 'font-awesome-last-used-release';
+
+	/**
 	 * Expiry time for the releases transient.
 	 *
 	 * @ignore
+	 * @internal
 	 */
 	const RELEASES_TRANSIENT_EXPIRY = YEAR_IN_SECONDS;
+
+	/**
+	 * Expiry time for the releases transient.
+	 *
+	 * @ignore
+	 * @internal
+	 */
+	const LAST_USED_RELEASE_TRANSIENT_EXPIRY = WEEK_IN_SECONDS;
 
 	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/**
@@ -105,15 +124,7 @@ class FontAwesome_Release_Provider {
 	 *
 	 * @ignore
 	 */
-	private function __construct() {
-		$transient_value = get_site_transient( self::RELEASES_TRANSIENT );
-
-		if ( $transient_value ) {
-			$this->releases       = $transient_value['data']['releases'];
-			$this->refreshed_at   = $transient_value['refreshed_at'];
-			$this->latest_version = $transient_value['data']['latest'];
-		}
-	}
+	private function __construct() {}
 
 	/**
 	 * Loads release metadata and saves to a transient.
@@ -281,7 +292,11 @@ EOD;
 			$transient_value = get_site_transient( self::RELEASES_TRANSIENT );
 
 			if ( $transient_value ) {
-				return $transient_value['data']['releases'];
+				$this->releases       = $transient_value['data']['releases'];
+				$this->refreshed_at   = $transient_value['refreshed_at'];
+				$this->latest_version = $transient_value['data']['latest'];
+
+				return $this->releases;
 			} elseif ( is_null( $this->releases ) ) {
 				$result = $this->load_releases();
 
@@ -359,6 +374,22 @@ EOD;
 			throw ConfigSchemaException::webfont_v4compat_introduced_later();
 		}
 
+		// If this is the same query as last time, then our LAST_USED_RELEASE_TRANSIENT should be current.
+		$last_used_transient = get_site_transient( self::LAST_USED_RELEASE_TRANSIENT );
+
+		if ( $last_used_transient ) {
+			// For simplicity, we're require that it's exactly what we're looking for, else we'll re-build and overwrite it.
+			if (
+				$version == $last_used_transient['version']
+				&& $flags['use_pro'] == $last_used_transient['use_pro']
+				&& $flags['use_svg'] == $last_used_transient['use_svg']
+				&& $flags['use_shim'] == $last_used_transient['use_shim']
+				&& is_array( $last_used_transient['resources'] )
+			) {
+				return new FontAwesome_ResourceCollection( $version, $last_used_transient['resources'] );
+			}
+		}
+
 		if ( ! array_key_exists( $version, $this->releases() ) ) {
 			throw new ReleaseMetadataMissingException();
 		}
@@ -366,6 +397,20 @@ EOD;
 		array_push( $resources, $this->build_resource( $version, 'all', $flags ) );
 		if ( $flags['use_shim'] ) {
 			array_push( $resources, $this->build_resource( $version, 'v4-shims', $flags ) );
+		}
+
+		$transient_value = array(
+			'version'   => $version,
+			'use_pro'   => $flags['use_pro'],
+			'use_svg'   => $flags['use_svg'],
+			'use_shim'  => $flags['use_shim'],
+			'resources' => $resources
+		);
+
+		$ret = set_site_transient( self::LAST_USED_RELEASE_TRANSIENT, $transient_value, self::LAST_USED_RELEASE_TRANSIENT_EXPIRY );
+
+		if ( ! $ret ) {
+			throw new ReleaseProviderStorageException();
 		}
 
 		return new FontAwesome_ResourceCollection( $version, $resources );

--- a/includes/class-fontawesome-release-provider.php
+++ b/includes/class-fontawesome-release-provider.php
@@ -48,7 +48,7 @@ class FontAwesome_Release_Provider {
 	 * @ignore
 	 * @internal
 	 */
-	const LAST_USED_RELEASE_TRANSIENT  = 'font-awesome-last-used-release';
+	const LAST_USED_RELEASE_TRANSIENT = 'font-awesome-last-used-release';
 
 	/**
 	 * Expiry time for the releases transient.
@@ -404,7 +404,7 @@ EOD;
 			'use_pro'   => $flags['use_pro'],
 			'use_svg'   => $flags['use_svg'],
 			'use_shim'  => $flags['use_shim'],
-			'resources' => $resources
+			'resources' => $resources,
 		);
 
 		$ret = set_site_transient( self::LAST_USED_RELEASE_TRANSIENT, $transient_value, self::LAST_USED_RELEASE_TRANSIENT_EXPIRY );

--- a/includes/class-fontawesome-release-provider.php
+++ b/includes/class-fontawesome-release-provider.php
@@ -64,7 +64,7 @@ class FontAwesome_Release_Provider {
 	 * @ignore
 	 * @internal
 	 */
-	const LAST_USED_RELEASE_TRANSIENT_EXPIRY = WEEK_IN_SECONDS;
+	const LAST_USED_RELEASE_TRANSIENT_EXPIRY = YEAR_IN_SECONDS;
 
 	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fontawesome, mlwilkerson, robmadole, frrrances, deathnfudge
 Stable tag: 4.0.0-rc20
 Tags: font, awesome, fontawesome, font-awesome, icon, svg, webfont
 Requires at least: 4.7
-Tested up to: 5.4
+Tested up to: 5.5.2
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fontawesome, mlwilkerson, robmadole, frrrances, deathnfudge
 Stable tag: 4.0.0-rc20
 Tags: font, awesome, fontawesome, font-awesome, icon, svg, webfont
 Requires at least: 4.7
-Tested up to: 5.5.2
+Tested up to: 5.5.3
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/_support/font-awesome-phpunit-util.php
+++ b/tests/_support/font-awesome-phpunit-util.php
@@ -98,5 +98,12 @@ function reset_db() {
 			throw new Exception( 'Unsuccessful clearing the Releases transient.' );
 		}
 	}
+
+	if ( ! delete_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT ) ) {
+		// false could mean either that it doesn't exist, or that the delete wasn't successful.
+		if ( get_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT ) ) {
+			throw new Exception( 'Unsuccessful clearing the Last Used Releases transient.' );
+		}
+	}
 }
 

--- a/tests/test-integration-release-provider-cache.php
+++ b/tests/test-integration-release-provider-cache.php
@@ -127,27 +127,35 @@ class ReleaseProviderIntegrationTest extends \WP_UnitTestCase {
 	}
 
 	public function test_last_used_cache() {
-		$all_releases_query_count = 0;
+		$all_releases_query_count      = 0;
 		$last_used_release_query_count = 0;
 
-		add_filter( "pre_site_transient_" . FontAwesome_Release_Provider::RELEASES_TRANSIENT, function() use( &$all_releases_query_count ) {
-			$all_releases_query_count++;
-			return false;
-		}, 0);
+		add_filter(
+			'pre_site_transient_' . FontAwesome_Release_Provider::RELEASES_TRANSIENT,
+			function() use ( &$all_releases_query_count ) {
+				$all_releases_query_count++;
+				return false;
+			},
+			0
+		);
 
-		add_filter( "pre_site_transient_" . FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT, function() use( &$last_used_release_query_count ) {
-			$last_used_release_query_count++;
-			return false;
-		}, 0);
+		add_filter(
+			'pre_site_transient_' . FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT,
+			function() use ( &$last_used_release_query_count ) {
+				$last_used_release_query_count++;
+				return false;
+			},
+			0
+		);
 
 		$this->prepare(
 			array(
-				self::build_success_response()
+				self::build_success_response(),
 			)
 		);
 
-		$this->assertEquals(1, $all_releases_query_count);
-		$this->assertEquals(0, $last_used_release_query_count );
+		$this->assertEquals( 1, $all_releases_query_count );
+		$this->assertEquals( 0, $last_used_release_query_count );
 
 		$resource_collection = $this->release_provider->get_resource_collection(
 			'5.4.1',
@@ -158,8 +166,8 @@ class ReleaseProviderIntegrationTest extends \WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals(1, $all_releases_query_count);
-		$this->assertEquals(1, $last_used_release_query_count );
+		$this->assertEquals( 1, $all_releases_query_count );
+		$this->assertEquals( 1, $last_used_release_query_count );
 
 		$resource_collection = $this->release_provider->get_resource_collection(
 			'5.4.1',

--- a/tests/test-integration-release-provider-cache.php
+++ b/tests/test-integration-release-provider-cache.php
@@ -78,7 +78,7 @@ class ReleaseProviderIntegrationTest extends \WP_UnitTestCase {
 	 * a locked load spec, once locked, will not depend on any subsequent network requests to the metadata API
 	 * in order to load correctly.
 	 */
-	public function test_caching() {
+	public function test_releases_caching() {
 		$this->prepare(
 			array(
 				self::build_success_response(), // An initial successful one.
@@ -124,5 +124,53 @@ class ReleaseProviderIntegrationTest extends \WP_UnitTestCase {
 		 * versions as the last time it was successful.
 		 */
 		$this->assertEquals( $versions, $this->release_provider->versions() );
+	}
+
+	public function test_last_used_cache() {
+		$all_releases_query_count = 0;
+		$last_used_release_query_count = 0;
+
+		add_filter( "pre_site_transient_" . FontAwesome_Release_Provider::RELEASES_TRANSIENT, function() use( &$all_releases_query_count ) {
+			$all_releases_query_count++;
+			return false;
+		}, 0);
+
+		add_filter( "pre_site_transient_" . FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT, function() use( &$last_used_release_query_count ) {
+			$last_used_release_query_count++;
+			return false;
+		}, 0);
+
+		$this->prepare(
+			array(
+				self::build_success_response()
+			)
+		);
+
+		$this->assertEquals(1, $all_releases_query_count);
+		$this->assertEquals(0, $last_used_release_query_count );
+
+		$resource_collection = $this->release_provider->get_resource_collection(
+			'5.4.1',
+			array(
+				'use_pro'  => true,
+				'use_svg'  => false,
+				'use_shim' => false,
+			)
+		);
+
+		$this->assertEquals(1, $all_releases_query_count);
+		$this->assertEquals(1, $last_used_release_query_count );
+
+		$resource_collection = $this->release_provider->get_resource_collection(
+			'5.4.1',
+			array(
+				'use_pro'  => true,
+				'use_svg'  => false,
+				'use_shim' => false,
+			)
+		);
+
+		$this->assertEquals( 2, $last_used_release_query_count );
+		$this->assertEquals( 1, $all_releases_query_count );
 	}
 }


### PR DESCRIPTION
closes #51 

Adding another layer of transient caching: cache just the last used resource collection from among the entire metadata collection, since most page loads only use that one.

The Release Provider will also no longer load all release metadata when constructed. It will only lazy-load it when those releases are requested via the existing API function (`releases()`).

- [x] set non-zero transient expiration for existing font-awesome-releases transient to disable autoloading 
- [x] prototype basic new functionality
- [x] update existing tests
- [x] add tests to ensure queries are appropriately limited
