### PR TITLE
Handle 5.x and 6.x kit versions

### DIFF
--- a/includes/class-fontawesome-config-controller.php
+++ b/includes/class-fontawesome-config-controller.php
@@ -215,11 +215,12 @@ class FontAwesome_Config_Controller extends WP_REST_Controller {
 		 * a major.minor.patch version like 5.12.0.
 		 *
 		 * If this is a kit-based config, then the version must either be
-		 * concrete or the exact, case-sensitive, string 'latest'.
+		 * concrete or one of the exact, case-sensitive, strings 'latest',
+		 * '5.x', or '6.x'.
 		 */
 		if ( isset( $given_options['kitToken'] ) && is_string( $given_options['kitToken'] ) && $version_is_symbolic_latest ) {
 			$item['version'] = 'latest';
-		} elseif ( $version_is_concrete ) {
+		} elseif ( $version_is_concrete || '5.x' === $given_options['version'] || '6.x' === $given_options['version']) {
 			$item['version'] = $given_options['version'];
 		} else {
 			throw ConfigSchemaException::concrete_version_expected();

--- a/includes/class-fontawesome-config-controller.php
+++ b/includes/class-fontawesome-config-controller.php
@@ -101,6 +101,10 @@ class FontAwesome_Config_Controller extends WP_REST_Controller {
 
 			$given_options = isset( $body['options'] ) ? $body['options'] : null;
 
+			if( is_null( $given_options ) ) {
+				return new FontAwesome_REST_Response( new WP_Error('fontawesome_client_exception'), 400 );
+			}
+
 			$api_token = isset( $given_options['apiToken'] ) ? $given_options['apiToken'] : null;
 
 			if ( is_string( $api_token ) ) {

--- a/includes/class-fontawesome-config-controller.php
+++ b/includes/class-fontawesome-config-controller.php
@@ -101,8 +101,8 @@ class FontAwesome_Config_Controller extends WP_REST_Controller {
 
 			$given_options = isset( $body['options'] ) ? $body['options'] : null;
 
-			if( is_null( $given_options ) ) {
-				return new FontAwesome_REST_Response( new WP_Error('fontawesome_client_exception'), 400 );
+			if ( is_null( $given_options ) ) {
+				return new FontAwesome_REST_Response( new WP_Error( 'fontawesome_client_exception' ), 400 );
 			}
 
 			$api_token = isset( $given_options['apiToken'] ) ? $given_options['apiToken'] : null;
@@ -224,7 +224,7 @@ class FontAwesome_Config_Controller extends WP_REST_Controller {
 		 */
 		if ( isset( $given_options['kitToken'] ) && is_string( $given_options['kitToken'] ) && $version_is_symbolic_latest ) {
 			$item['version'] = 'latest';
-		} elseif ( $version_is_concrete || '5.x' === $given_options['version'] || '6.x' === $given_options['version']) {
+		} elseif ( $version_is_concrete || '5.x' === $given_options['version'] || '6.x' === $given_options['version'] ) {
 			$item['version'] = $given_options['version'];
 		} else {
 			throw ConfigSchemaException::concrete_version_expected();

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -923,8 +923,9 @@ class FontAwesome {
 			}
 		} else {
 			/**
-			 * If we're not using a kit, then the version cannot be "latest" at this
-			 * point. It must have already been resolved into a concrete version.
+			 * If we're not using a kit, then the version cannot be "latest",
+			 * "5.x", or "6.x" at this point. It must have already been resolved
+			 * into a concrete version.
 			 */
 			$version_is_concrete = is_string( $version )
 				&& 1 === preg_match( '/^[0-9]+\.[0-9]+\.[0-9]+/', $version );
@@ -1280,7 +1281,10 @@ class FontAwesome {
 	}
 
 	/**
-	 * Reports the version of Font Awesome assets being loaded, which may be "latest".
+	 * Reports the version of Font Awesome assets being loaded, which may have
+	 * a symbolic value like "latest" (deprecated), "5.x", or "6.x" if configured
+	 * for a kit. If not configured for a kit, the version is guaranteed to be
+	 * a concrete, semver parseable value, like 5.15.3.
 	 *
 	 * Your theme or plugin can call this method in order to determine
 	 * whether all of the icons used in your templates will be available,
@@ -1297,44 +1301,30 @@ class FontAwesome {
 	 * version happens internal to the kit's own loading logic, which is
 	 * outside the scope of this plugin.
 	 *
-	 * If your code needs to resolve what that concrete version will _probably_
-	 * be at runtime, you can take some extra steps after invoking this method
-	 * and seeing that it returns "latest".
+	 * Before the release of Font Awesome 6.0.0-beta1, the symbolic version "latest"
+	 * on a kit always meant: "the latest stable release with major version 5."
+	 * Using "latest" for kits has been deprecated, but where it is still present
+	 * on a kit, it will continue to mean just "the latest stable release with
+	 * major version 5."
 	 *
-	 * - `fa()->latest_version()` will only ever return the latest known
-	 *     concrete version of Font Awesome, as recently as the last time the
-	 *     releases metadata was queried from the Font Awesome API server.
+	 * New symbolic major version ranges have been introduced instead "5.x" and "6.x".
+	 * These mean, respectively: "the latest stable release with major version 5",
+	 * and "the latest stable release with major version 6, when available, otherwise
+	 * the latest pre-release with major version 6."
 	 *
-	 * - `fa()->releases_refreshed_at()` will return the time when releases
-	 *     metadata was last refreshed.
-	 *
-	 * Releases are refreshed when the admin user loads the Font Awesome settings
-	 * page if it's been longer than the {@see FortAwesome\FontAwesome::RELEASES_REFRESH_INTERVAL}.
-	 *
-	 * If you think the releases metadata should be refreshed, the best approach
-	 * would be to alert the user in the admin dashboard, requesting that they
-	 * refresh releases by simply re-loading the Font Awesome settings page.
-	 *
-	 * It is still possible that by the time the page loads in the browser,
-	 * a new release of Font Awesome will have become available since the last
-	 * refresh of releases metadata, and will have been loaded as the "latest"
-	 * version for the kit. There's no way to guarantee that the latest version
-	 * you resolve by this method will be the one loaded at runtime. The race
-	 * condition is always possible. However, it is very unlikely, since these
-	 * are sub-second windows of time, and new versions of Font Awesome tend to
-	 * be released only approximately once per month.
-	 *
-	 * (We want to avoid making a synchronous network request to the API server
-	 * on normal front end page loads, so there's currently no supported way in
-	 * this API to programatically force the reload of metadata.)
+	 * These "5.x" and "6.x" symbolic versions should not be relied upon
+	 * as API at this time, because this schema may change. Suffice it to say
+	 * that if this function does not return a semver parseable version, then
+	 * it probably means that it's one of these symbolic versions, and there's
+	 * currently no way to reliably, programmatically convert that symbolic
+	 * version into the concrete version that will be loaded by the kit.
 	 *
 	 * @since 4.0.0
 	 * @see FontAwesome::latest_version()
 	 * @see FontAwesome::releases_refreshed_at()
 	 * @throws ConfigCorruptionException
 	 * @return string|null null if no version has yet been saved in the options
-	 * in the db. Otherwise, a valid version string, which may be either a
-	 * concrete version like "5.12.0" or the string "latest".
+	 * in the db. Otherwise, a version string.
 	 */
 	public function version() {
 		$options = $this->options();

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -608,11 +608,18 @@ class FontAwesome {
 	}
 
 	/**
-	 * Returns the latest available version of Font Awesome as a string, or null
-	 * if the releases metadata has not yet been successfully retrieved from the
+	 * Returns the latest available full release version of Font Awesome 5 as a string,
+	 * or null if the releases metadata has not yet been successfully retrieved from the
 	 * API server.
 	 *
+	 * As of the release of Font Awesome 6.0.0-beta1, this API is being deprecated,
+	 * because the symbolic version "latest" is being deprecated. It now just means
+	 * "the latest full release of Font Awesome with major version 5." Therefore,
+	 * it may not be very useful any more as Font Awesome 6 is released.
+	 *
 	 * @since 4.0.0
+	 * @deprecated
+	 * @ignore
 	 *
 	 * @return null|string
 	 */

--- a/tests/test-config-controller.php
+++ b/tests/test-config-controller.php
@@ -128,6 +128,74 @@ class ConfigControllerTest extends \WP_UnitTestCase {
 		$this->assertEquals( '5.4.1', fa()->version() );
 	}
 
+	/**
+	 * When we update the options to use a kit, and that kit's version is not
+	 * 'latest', but a major version range, '5.x' or '6.x' then that range
+	 * value is what is stored.
+	 */
+	public function test_update_kit_major_version_range() {
+		// Start with the version being something else.
+		$this->set_version( '5.3.1' );
+
+		$request_body = array(
+				'options' => array(
+					'usePro' => true,
+					'v4Compat' => true,
+					'technology' => 'webfont',
+					'pseudoElements' => true,
+					'kitToken' => '778ccf8260',
+					'apiToken' => true,
+					'version' => '5.x',
+				),
+				'conflicts' => array()
+			);
+
+		$request  = new \WP_REST_Request(
+			'PUT',
+			$this->namespaced_route
+		);
+
+    	$request->add_header('Content-Type', 'application/json');
+    	$request->set_body( wp_json_encode( $request_body ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'conflicts', $data );
+		$this->assertArrayHasKey( 'options', $data );
+		$this->assertEquals( '5.x', $data['options']['version']);
+		$this->assertEquals( '5.x', fa()->version() );
+
+		// Now try 6.x
+
+		$request_body = array(
+				'options' => array(
+					'usePro' => true,
+					'v4Compat' => true,
+					'technology' => 'webfont',
+					'pseudoElements' => true,
+					'kitToken' => '778ccf8260',
+					'apiToken' => true,
+					'version' => '6.x',
+				),
+				'conflicts' => array()
+			);
+
+		$request  = new \WP_REST_Request(
+			'PUT',
+			$this->namespaced_route
+		);
+
+    	$request->add_header('Content-Type', 'application/json');
+    	$request->set_body( wp_json_encode( $request_body ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'conflicts', $data );
+		$this->assertArrayHasKey( 'options', $data );
+		$this->assertEquals( '6.x', $data['options']['version']);
+		$this->assertEquals( '6.x', fa()->version() );
+	}
+
 	public function test_update_with_kit_using_symbolic_latest_version() {
 		// Start with the version being something else.
 		$this->set_version( '5.3.1' );


### PR DESCRIPTION
Font Awesome is deprecating the symbolic version "latest" for kits and using "5.x" for the latest stable release in major version 5, and "6.x" for the latest with major version 6.

This PR changes how the kit.version field is handled to allow for this change, and updates inline code documentation accordingly.