### PR TITLE
remove and document widget_text do_shortcode filter

### DIFF
--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -377,8 +377,6 @@ class FontAwesome {
 				array( $this, 'process_shortcode' )
 			);
 
-			add_filter( 'widget_text', 'do_shortcode' );
-
 			$this->validate_options( fa()->options() );
 
 			try {

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ You can get more information about using the plugin, details for available setti
 
 == Upgrade Notice ==
 = 4.0 =
-The 4.0 official release from the Font Awesome team is a major upgrade from the previous 3.x plugin, but has no breaking changes from the previous 4.0 release candidate. Adds an Icon Chooser feature. See Changelog for details.
+The 4.0 official release from the Font Awesome team is a major upgrade from the previous 3.x plugin. Only one breaking change from previous release candidate: plugin no longer adds a filter to process shortcodes in widget text. Adds an Icon Chooser feature. See Changelog for details.
 
 = 4.0.0-rc22 =
 
@@ -157,6 +157,13 @@ You can get more information about all the available settings and troubleshootin
 * FEATURE: Visual icon chooser lets you search and easily insert the correct shortcode.
 * Fixed regression on overriding global lodash version.
 * Added PHP API method to get current Kit token.
+* Removed the filter to process all shortcodes in widget text. This seems to have been
+  an overly eager approach on our part. If you want shortcodes to be processed
+  in widget text - all shortcodes, not just this plugin's icon shortcode - you can
+  add a line like this to your theme's functions.php file:
+  ```
+  add_filter( 'widget_text', 'do_shortcode' );
+  ```
 
 = 4.0.0-rc23 =
 


### PR DESCRIPTION
@frrrances what do you think of including this? It's technically a breaking change, though it seems pretty minor.

I discovered it when looking into how to capture that issue we noticed with shortcodes not being processed in the post excerpts. Seems like something should probably be the concern of a theme, instead of this plugin, since invoking `do_shortcode` would not only process _our_ shortcode, but _all_ registered shortcodes.

I realized that we were already doing something like that for `widget_text` (see the diffs). In other words, we were invoking the processing of _all_ shortcodes for `widget_text`. I think that's a side effect that this plugin should not be causing.

It's possible that users will have come to rely on that side effect though, which is why it would be a breaking change. In the readme.txt I offered a one-liner that could be added to their theme to re-enable this if that's what they still want.

This also seems to confirm for me that, by analogy, when it comes to the excerpt text, it _is_ the concern of the theme--and not this plugin--to determine whether shortcode processing should be enabled there.