### PR TITLE
Editor Integration Bugfixes

### DIFF
--- a/admin/src/chooser/classicEditor.js
+++ b/admin/src/chooser/classicEditor.js
@@ -11,7 +11,7 @@ export function handleSubmit(event) {
 export function setupClassicEditor(params) {
   const {
     iconChooserContainerId,
-    iconChooserMediaButtonId,
+    iconChooserMediaButtonClass,
     modalOpenEvent,
     kitToken,
     version,
@@ -22,8 +22,8 @@ export function setupClassicEditor(params) {
   } = params
 
   // TODO: decide what to do about these early-return error conditions.
-  const mediaButton = document.querySelector(`#${iconChooserMediaButtonId}`)
-  if(!mediaButton) return
+  const mediaButtons = document.querySelectorAll(`.${iconChooserMediaButtonClass}`)
+  if(!mediaButtons || 0 === mediaButtons.length) return
   const container = document.querySelector(`#${iconChooserContainerId}`)
   if(!container) return
   if(!window.tinymce) return
@@ -54,9 +54,11 @@ export function setupClassicEditor(params) {
   })
   */
 
-  mediaButton.addEventListener('click', () => {
-    document.dispatchEvent(modalOpenEvent)
-  })
+  for(const button of mediaButtons) {
+    button.addEventListener('click', () => {
+      document.dispatchEvent(modalOpenEvent)
+    })
+  }
 
   const render = get(window, 'wp.element.render', fallbackReactDom.render)
 

--- a/admin/src/chooser/index.js
+++ b/admin/src/chooser/index.js
@@ -26,26 +26,21 @@ export function setupIconChooser(initialParams) {
     modalOpenEvent: new Event('fontAwesomeIconChooserOpen', { "bubbles": true, "cancelable": false })
   }
 
+  if( get(window, 'wp.element') ) {
+    setupBlockEditor(params)
+  }
+
   /**
    * Tiny MCE loading time: In WordPress 5, it's straightforward to enqueue
    * this script with a script dependency of wp-tinymce. But that's not available
    * in WP 4, and there doesn't seem to be any way to ensure that the Tiny MCE
    * script has been loaded before this, other than to add a script after the
-   * Tiny MCE scripts have been printed. So that's what we'll do.
-   *
-   * We'll expose a global function from here that the later loading script
-   * can invoke to set up the Tiny MCE Icon Chooser integration.
+   * Tiny MCE scripts have been printed.
+   * 
+   * So what we'll do instead is simply export this function that can be exposed
+   * as a global function, and in our back end PHP code, we'll add an inline script
+   * to invoke that global for tinyMCE setup if and when it is necessary.
    */
-  if(window.tinymce) {
-    // If tinymce is already loaded, we can set it up now.
-    setupClassicEditorIconChooser(params)
-  }
-
-  if( get(window, 'wp.element') ) {
-    setupBlockEditor(params)
-  }
-
-  // Returns that can be used to set up global hooks
   return {
     setupClassicEditorIconChooser: () => setupClassicEditorIconChooser(params)
   }

--- a/admin/src/chooser/index.js
+++ b/admin/src/chooser/index.js
@@ -36,7 +36,7 @@ export function setupIconChooser(initialParams) {
    * in WP 4, and there doesn't seem to be any way to ensure that the Tiny MCE
    * script has been loaded before this, other than to add a script after the
    * Tiny MCE scripts have been printed.
-   * 
+   *
    * So what we'll do instead is simply export this function that can be exposed
    * as a global function, and in our back end PHP code, we'll add an inline script
    * to invoke that global for tinyMCE setup if and when it is necessary.

--- a/admin/src/chooser/index.js
+++ b/admin/src/chooser/index.js
@@ -12,7 +12,7 @@ function setupClassicEditorIconChooser(initialParams) {
   const params = {
     ...initialParams,
     iconChooserContainerId: 'font-awesome-icon-chooser-container',
-    iconChooserMediaButtonId: 'font-awesome-icon-chooser-media-button'
+    iconChooserMediaButtonClass: 'font-awesome-icon-chooser-media-button'
   }
 
   setupClassicEditor(params)

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1642,12 +1642,15 @@ class FontAwesome {
 		$js_url_id = 0;
 		$deps      = array();
 
-		/**
-		 * If enabling the icon chooser, then our admin bundle will depend on
-		 * some other scripts.
-		 */
 		if ( $enable_icon_chooser ) {
-			if ( function_exists( 'register_block_type' ) ) {
+			/**
+			 * If enabling the icon chooser, then our admin bundle will depend on
+			 * some other scripts.
+			 *
+			 * If we're on a Gutenberg page, whether we're in WP 5 or WP 4, this function will exist,
+			 * and we'll declare the corresponding dependencies.
+			 */
+			if( $this->is_gutenberg_page() ) {
 				$gutenberg_deps = array(
 					'wp-blocks',
 					'wp-i18n',
@@ -1659,13 +1662,29 @@ class FontAwesome {
 				foreach ( $gutenberg_deps as $dep ) {
 					array_push( $deps, $dep );
 				}
+			} else {
+				/**
+				 * TODO: re-enable the case where TinyMCE and Gutenberg are present on the same
+				 * page load. For now, we're eliminating that case because
+				 * some customers experienced Gutenberg failures on pages where both
+				 * editors were active.
+				 * 
+				 * If we're not on a Gutenberg (as plugin) or Block Editor (as WP 5 Core editor),
+				 * then we want to enable our TinyMCE integration. We'll initialize it
+				 * on the wp_tiny_mce_init action hook.
+				 *
+				 * According to the docs:
+				 * "Fires after tinymce.js is loaded, but before any TinyMCE editor instances are created."
+				 *
+				 * So we expect this to only fire once, even if multiple instances of the editor
+				 * are added to a single page.
+				 *
+				 * If TinyMCE is not present or not active, then this action hook will
+				 * never be fired and thus our TinyMCE integration will never be setup,
+				 * which is what we want.
+				 */
+				add_action( 'wp_tiny_mce_init', array( $this, 'print_classic_editor_icon_chooser_setup_script' ) );
 			}
-
-			/**
-			 * Whether we're in WP 4, or using Classic Editor in WP 5, this will
-			 * trigger the Tiny MCE support in the Icon Chooser.
-			 */
-			add_action( 'wp_tiny_mce_init', array( $this, 'print_classic_editor_icon_chooser_setup_script' ) );
 		}
 
 		foreach ( $js_entrypoint_urls as $js_url ) {
@@ -2893,6 +2912,31 @@ EOT;
 		}
 
 		return false !== array_search( $screen_id, $this->icon_chooser_screens, true );
+	}
+
+	/**
+	 * Internal use only, not part of this plugin's public API.
+	 *
+	 * Code borrowed from Freemius SDK by way of Benjamin Intal on Stack Overflow,
+	 * under GPL. Thanks Benjamin! Hey everybody, get the Stackable plugin to do
+	 * cool stuff with Font Awesome in your Blocks!
+	 *
+	 * See: https://github.com/Freemius/wordpress-sdk
+	 * See: https://wordpress.stackexchange.com/questions/309862/check-if-gutenberg-is-currently-in-use
+	 * See: https://wordpress.org/plugins/stackable-ultimate-gutenberg-blocks/
+	 */
+	private function is_gutenberg_page() {
+		if ( function_exists( 'is_gutenberg_page' ) && is_gutenberg_page() ) {
+			// The Gutenberg plugin is on.
+			return true;
+		}
+		$current_screen = get_current_screen();
+		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+			// Gutenberg page on 5+.
+			return true;
+		}
+
+		return false;		
 	}
 
 	/**

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1559,7 +1559,7 @@ class FontAwesome {
 					 * Here's the recommendation we're following here:
 					 * https://make.wordpress.org/core/2018/12/06/javascript-packages-and-interoperability-in-5-0-and-beyond/
 					 */
-					$vendor_globals = ['_', 'React', 'ReactDOM', 'moment'];
+					$vendor_globals = array( '_', 'React', 'ReactDOM', 'moment' );
 
 					$originals_global = '__originalsBeforeFontAwesome';
 
@@ -1573,7 +1573,7 @@ class FontAwesome {
 					$capture_vendor_global_originals_script = sprintf(
 						'window.%1$s = { %2$s }',
 						$originals_global,
-						implode(',', $originals)
+						implode( ',', $originals )
 					);
 
 					wp_add_inline_script(
@@ -1591,7 +1591,7 @@ class FontAwesome {
 
 					wp_add_inline_script(
 						self::ADMIN_RESOURCE_HANDLE,
-						implode(' ', $original_restore_conditions),
+						implode( ' ', $original_restore_conditions ),
 						'after'
 					);
 				} catch ( Exception $e ) {
@@ -1683,7 +1683,7 @@ class FontAwesome {
 			 * If we're on a Gutenberg page, whether we're in WP 5 or WP 4, this function will exist,
 			 * and we'll declare the corresponding dependencies.
 			 */
-			if( $this->is_gutenberg_page() ) {
+			if ( $this->is_gutenberg_page() ) {
 				$gutenberg_deps = array(
 					'wp-blocks',
 					'wp-i18n',
@@ -1701,7 +1701,7 @@ class FontAwesome {
 				 * page load. For now, we're eliminating that case because
 				 * some customers experienced Gutenberg failures on pages where both
 				 * editors were active.
-				 * 
+				 *
 				 * If we're not on a Gutenberg (as plugin) or Block Editor (as WP 5 Core editor),
 				 * then we want to enable our TinyMCE integration. We'll initialize it
 				 * on the wp_tiny_mce_init action hook.
@@ -2969,7 +2969,7 @@ EOT;
 			return true;
 		}
 
-		return false;		
+		return false;
 	}
 
 	/**

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1528,7 +1528,7 @@ class FontAwesome {
 										'%1$sAdd Font Awesome%2$s',
 										'font-awesome'
 									),
-									'<button type="button" class="button" id="font-awesome-icon-chooser-media-button"><i class="fab fa-font-awesome-flag"></i> ',
+									'<button type="button" class="button font-awesome-icon-chooser-media-button"><i class="fab fa-font-awesome-flag"></i> ',
 									'</button>'
 								);
 							},


### PR DESCRIPTION
Closes #133

Also fixes the Icon Chooser media button in the classic editor, where there are multiple instances of TinyMCE. Before, only the first of those buttons was properly wired up to pop-up the Icon Chooser modal. Now, any of them on the page will be properly wired up.