### PR TITLE
Remove wp-editor and wp-blocks deps when integrating with Classic Editor

### DIFF
--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -126,7 +126,7 @@ class FontAwesome {
 	 *
 	 * @since 4.0.0
 	 */
-	const PLUGIN_VERSION = '4.0.2';
+	const PLUGIN_VERSION = '4.0.3-rc1';
 	/**
 	 * The namespace for this plugin's REST API.
 	 *

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1686,7 +1686,14 @@ class FontAwesome {
 		} else {
 			$deps = array_merge( $deps, array( 'react', 'react-dom', 'wp-i18n', 'wp-element', 'wp-components', 'wp-api-fetch' ) );
 
-			if ( $enable_icon_chooser ) {
+			/**
+			 * We don't need these Gutenberg dependencies unless we're on a Gutenberg
+			 * page. Declaring them unnecessarily (when not on a Gutenberg page)
+			 * has resulted in conflict for at least one other plugin: RankMath.
+			 *
+			 * See: https://wordpress.org/support/topic/plugin-conflicts-with-rankmath
+			 */
+			if ( $enable_icon_chooser && $this->is_gutenberg_page() ) {
 				$deps = array_merge( $deps, array( 'wp-blocks', 'wp-editor' ) );
 			}
 		}

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Font Awesome
  * Plugin URI:        https://fontawesome.com/how-to-use/on-the-web/using-with/wordpress
  * Description:       The official way to use Font Awesome Free or Pro icons on your site, brought to you by the Font Awesome team.
- * Version:           4.0.2
+ * Version:           4.0.3-rc1
  * Author:            Font Awesome
  * Author URI:        https://fontawesome.com/
  * License:           GPLv2 (or later)


### PR DESCRIPTION
This is to address the issue reported in the [plugin support forum here](https://wordpress.org/support/topic/plugin-conflicts-with-rankmath/).