### PR TITLE
No metadata refresh on upgrade

### DIFF
--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -536,8 +536,10 @@ class FontAwesome {
 		}
 
 		// It used to be stored in one of these.
-		$release_metadata = get_site_transient( 'font-awesome-releases' )
-			|| get_transient( 'font-awesome-releases' );
+		$release_metadata = get_site_transient( 'font-awesome-releases' );
+		if ( !$release_metadata ) {
+			$release_metadata = get_transient( 'font-awesome-releases' );
+		}
 
 		// Move it into where it belongs now.
 		if ( boolval( $release_metadata ) ) {
@@ -565,8 +567,10 @@ class FontAwesome {
 	 * @internal
 	 */
 	private function maybe_update_last_used_release_schema_for_upgrade() {
-		$last_used_transient = get_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT )
-			|| get_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
+		$last_used_transient = get_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
+		if ( !$last_used_transient ) {
+			$last_used_transient = get_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
+		}
 
 		if ( $last_used_transient && isset( $last_used_transient['use_shim'] ) ) {
 			$compat = $last_used_transient['use_shim'];

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -439,6 +439,7 @@ class FontAwesome {
 	 * @throws ApiRequestException
 	 * @throws ApiResponseException
 	 * @throws ReleaseProviderStorageException
+	 * @throws ReleaseMetadataMissingException
 	 * @throws ConfigCorruptionException if options are invalid
 	 * @internal
 	 * @ignore
@@ -491,7 +492,7 @@ class FontAwesome {
 		if ( $should_upgrade ) {
 			$this->validate_options( $options );
 
-			$this->reset_releases_metadata_for_upgrade();
+			$this->maybe_move_release_metadata_for_upgrade();
 
 			/**
 			 * Delete the main option to make sure it's removed entirely, including
@@ -511,28 +512,44 @@ class FontAwesome {
 	}
 
 	/**
+	 * Some upgrades have involved changing how we store release metadata.
+	 *
+	 * If the plugin's backing data was in a valid sate before upgrade, then
+	 * it should always be possible to apply any fixups to how the release
+	 * metadata are stored without issuing a request to the API server for
+	 * fresh metadata. Since issuing such a blocking request upon upgrade
+	 * is known to cause load problems and request timeouts, let's never
+	 * do it on upgrade.
+	 *
 	 * Internal use only.
 	 *
+	 * @throws ReleaseMetadataMissingException
 	 * @ignore
 	 * @internal
 	 */
-	private function reset_releases_metadata_for_upgrade() {
-		/**
-		 * Delete the old release metadata transient, if it exists,
-		 * which would not yet have been a site transient.
-		 */
-		delete_transient( 'font-awesome-releases' );
+	private function maybe_move_release_metadata_for_upgrade() {
+		if ( boolval( get_option( FontAwesome_Release_Provider::OPTIONS_KEY ) ) ) {
+			// If this option is set, then we're all caught up.
+			return;
+		}
 
-		// Delete the current site transients.
-		delete_site_transient( FontAwesome_Release_Provider::OPTIONS_KEY );
-		delete_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
+		// It used to be stored in one of these.
+		$release_metadata = get_site_transient( 'font-awesome-releases' )
+			|| get_transient( 'font-awesome-releases' );
+
+		// Move it into where it belongs now.
+		if ( boolval( $release_metadata ) ) {
+			update_option( FontAwesome_Release_Provider::OPTIONS_KEY, $release_metadata, false );
+		}
 
 		/**
-		 * This is one exception to the rule about not loading release metadata
-		 * on front end page loads. But this would only happen on the first page
-		 * load after upgrading from a particular range of earlier versions.
+		 * Now we'll reset the release provider.
+		 *
+		 * If we've fallen through to this point, and we haven't found the release
+		 * metadata stored in one of the previous locations, then this will throw an
+		 * exception.
 		 */
-		FontAwesome_Release_Provider::load_releases();
+		FontAwesome_Release_Provider::reset();
 	}
 
 	/**

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -537,7 +537,7 @@ class FontAwesome {
 
 		// It used to be stored in one of these.
 		$release_metadata = get_site_transient( 'font-awesome-releases' );
-		if ( !$release_metadata ) {
+		if ( ! $release_metadata ) {
 			$release_metadata = get_transient( 'font-awesome-releases' );
 		}
 
@@ -568,7 +568,7 @@ class FontAwesome {
 	 */
 	private function maybe_update_last_used_release_schema_for_upgrade() {
 		$last_used_transient = get_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
-		if ( !$last_used_transient ) {
+		if ( ! $last_used_transient ) {
 			$last_used_transient = get_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
 		}
 

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -492,6 +492,8 @@ class FontAwesome {
 		if ( $should_upgrade ) {
 			$this->validate_options( $options );
 
+			$this->maybe_update_last_used_release_schema_for_upgrade();
+
 			$this->maybe_move_release_metadata_for_upgrade();
 
 			/**
@@ -550,6 +552,28 @@ class FontAwesome {
 		 * exception.
 		 */
 		FontAwesome_Release_Provider::reset();
+	}
+
+	/**
+	 * With 4.1.0, the name of one of the keys in the LAST_USED_RELEASE_TRANSIENT changed.
+	 * We can fix it up.
+	 *
+	 * Internal use only.
+	 *
+	 * @throws ReleaseMetadataMissingException
+	 * @ignore
+	 * @internal
+	 */
+	private function maybe_update_last_used_release_schema_for_upgrade() {
+		$last_used_transient = get_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT )
+			|| get_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT );
+
+		if ( $last_used_transient && isset( $last_used_transient['use_shim'] ) ) {
+			$compat = $last_used_transient['use_shim'];
+			unset( $last_used_transient['use_shim'] );
+			$last_used_transient['use_compatibility'] = $compat;
+			set_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT, $last_used_transient, FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT_EXPIRY );
+		}
 	}
 
 	/**

--- a/tests/_support/font-awesome-phpunit-util.php
+++ b/tests/_support/font-awesome-phpunit-util.php
@@ -102,7 +102,14 @@ function reset_db() {
 	if ( ! delete_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT ) ) {
 		// false could mean either that it doesn't exist, or that the delete wasn't successful.
 		if ( get_site_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT ) ) {
-			throw new Exception( 'Unsuccessful clearing the Last Used Releases transient.' );
+			throw new Exception( 'Unsuccessful clearing the Last Used Release site transient.' );
+		}
+	}
+
+	if ( ! delete_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT ) ) {
+		// false could mean either that it doesn't exist, or that the delete wasn't successful.
+		if ( get_transient( FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT ) ) {
+			throw new Exception( 'Unsuccessful clearing the Last Used Release transient.' );
 		}
 	}
 }

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -281,7 +281,11 @@ class OptionsTest extends TestCase {
 		);
 	}
 
-	public function test_try_upgrade_when_upgraded_with_prior_releases_metadata_transient() {
+	public function try_upgrade_when_upgraded_with_prior_releases_metadata_transient( $initialize ) {
+		if ( !is_callable( $initialize ) ) {
+			throw new \Exception();
+		}
+
 		// First, establish what's expected.
 		FontAwesome_Release_Provider::load_releases();
 		$expected = get_option( FontAwesome_Release_Provider::OPTIONS_KEY );
@@ -308,8 +312,7 @@ class OptionsTest extends TestCase {
 			)
 		);
 
-		// Simulate storing it in this alternative location.
-		set_transient( 'font-awesome-releases', $expected );
+		$initialize( $expected );
 
 		// Now try to upgrade.
 		fa()->try_upgrade();
@@ -318,6 +321,15 @@ class OptionsTest extends TestCase {
 		$this->assertTrue( boolval( FontAwesome_Release_Provider::reset() ) );
 
 		$this->assertEquals( get_option( FontAwesome_Release_Provider::OPTIONS_KEY ), $expected );
+	}
+
+	public function test_upgrade_when_upgraded_with_prior_releases_metadata_transient() {
+		$this->try_upgrade_when_upgraded_with_prior_releases_metadata_transient(
+			function( $expected ) {
+				// Simulate storing it in this alternative location.
+				set_transient( 'font-awesome-releases', $expected );
+			}
+		);
 	}
 
 	/**

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -123,6 +123,8 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_try_upgrade_when_upgrade_required_from_pre_rc13() {
+		$this->block_metadata_query();
+
 		update_option(
 			FontAwesome::OPTIONS_KEY,
 			array (
@@ -173,6 +175,8 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_try_upgrade_when_upgrade_required_from_post_rc13_pre_rc22() {
+		$this->block_metadata_query();
+
 		update_option(
 			FontAwesome::OPTIONS_KEY,
 			array(
@@ -208,6 +212,8 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_try_upgrade_from_v4_compat_to_compat_option() {
+		$this->block_metadata_query();
+
 		update_option(
 			FontAwesome::OPTIONS_KEY,
 			array(
@@ -243,6 +249,8 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_try_upgrade_when_upgrade_not_required() {
+		$this->block_metadata_query();
+
 		update_option(
 			FontAwesome::OPTIONS_KEY,
 			array_merge(

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -43,6 +43,21 @@ class OptionsTest extends TestCase {
 		);
 	}
 
+	public function tear_down() {
+		FontAwesome_Metadata_Provider::reset();
+	}
+
+	protected function block_metadata_query() {
+		mock_singleton_method(
+			$this,
+			FontAwesome_Metadata_Provider::class,
+			'metadata_query',
+			function( $method ) {
+				$method->willThrowException( new \Exception('unexpected: metadata_query was invoked') );
+			}
+		);
+	}
+
 	public function test_option_defaults() {
 		FontAwesome_Activator::activate();
 
@@ -256,6 +271,18 @@ class OptionsTest extends TestCase {
 			),
 			fa()->options()
 		);
+	}
+
+	/**
+	 * This tests our block_metadata_query(), making sure that if metadata_query is invoked
+	 * after being blocked, then we get an exception.
+	 */
+	public function test_block_metadata_query() {
+		$this->block_metadata_query();
+
+		$this->expectException( \Exception::class );
+
+		FontAwesome_Release_Provider::load_releases();
 	}
 
 	public function test_convert_options_from_v1_coerce_pseudo_elements_true_for_webfont() {

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -353,9 +353,8 @@ class OptionsTest extends TestCase {
 
 	public function test_upgrade_when_upgraded_with_prior_releases_metadata_transient_and_old_last_used_release_transient() {
 		$this->try_upgrade_when_upgraded_with_prior_releases_metadata_transient(
-			function( $expected ) {
-				// Simulate storing it in this alternative location.
-				set_transient( 'font-awesome-releases', $expected );
+			function( $releases_option_value ) {
+				update_option( FontAwesome_Release_Provider::OPTIONS_KEY, $releases_option_value );
 
 				set_transient(
 					FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT,
@@ -381,10 +380,8 @@ class OptionsTest extends TestCase {
 
 	public function test_upgrade_when_upgraded_with_prior_releases_metadata_transient_and_old_last_used_release_site_transient() {
 		$this->try_upgrade_when_upgraded_with_prior_releases_metadata_transient(
-			function( $expected ) {
-				// Simulate storing it in this alternative location.
-				set_transient( 'font-awesome-releases', $expected );
-
+			function( $releases_option_value ) {
+				update_option( FontAwesome_Release_Provider::OPTIONS_KEY, $releases_option_value );
 				set_site_transient(
 					FontAwesome_Release_Provider::LAST_USED_RELEASE_TRANSIENT,
 					// A partial value is good enough here.

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -281,8 +281,8 @@ class OptionsTest extends TestCase {
 		);
 	}
 
-	public function try_upgrade_when_upgraded_with_prior_releases_metadata_transient( $initialize ) {
-		if ( !is_callable( $initialize ) ) {
+	public function try_upgrade_when_upgraded_with_prior_releases_metadata_transient( $initialize, $assert_expectations ) {
+		if ( !is_callable( $initialize ) || !is_callable( $assert_expectations )) {
 			throw new \Exception();
 		}
 
@@ -320,7 +320,7 @@ class OptionsTest extends TestCase {
 		// If we can reset without throwing an exception, it means we migrated *something*.
 		$this->assertTrue( boolval( FontAwesome_Release_Provider::reset() ) );
 
-		$this->assertEquals( get_option( FontAwesome_Release_Provider::OPTIONS_KEY ), $expected );
+		$assert_expectations( $expected );
 	}
 
 	public function test_upgrade_when_upgraded_with_prior_releases_metadata_transient() {
@@ -328,6 +328,9 @@ class OptionsTest extends TestCase {
 			function( $expected ) {
 				// Simulate storing it in this alternative location.
 				set_transient( 'font-awesome-releases', $expected );
+			},
+			function( $expected ) {
+				$this->assertEquals( get_option( FontAwesome_Release_Provider::OPTIONS_KEY ), $expected );
 			}
 		);
 	}
@@ -337,6 +340,9 @@ class OptionsTest extends TestCase {
 			function( $expected ) {
 				// Simulate storing it in this alternative location.
 				set_site_transient( 'font-awesome-releases', $expected );
+			},
+			function( $expected ) {
+				$this->assertEquals( get_option( FontAwesome_Release_Provider::OPTIONS_KEY ), $expected );
 			}
 		);
 	}

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -332,6 +332,15 @@ class OptionsTest extends TestCase {
 		);
 	}
 
+	public function test_upgrade_when_upgraded_with_prior_releases_metadata_site_transient() {
+		$this->try_upgrade_when_upgraded_with_prior_releases_metadata_transient(
+			function( $expected ) {
+				// Simulate storing it in this alternative location.
+				set_site_transient( 'font-awesome-releases', $expected );
+			}
+		);
+	}
+
 	/**
 	 * This tests our block_metadata_query(), making sure that if metadata_query is invoked
 	 * after being blocked, then we get an exception.


### PR DESCRIPTION
This removes any logic in try_upgrade() that might result in an blocking network request being made. That's how it had been previously, and should be again. Also added some tests to ensure that this behavior doesn't revert accidentally in the future.