### PR TITLE
defer loading of kit loader scripts

### DIFF
--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1988,7 +1988,7 @@ EOT;
 				if ( self::RESOURCE_HANDLE === $handle ) {
 					$revised_html = preg_replace(
 						'/<script[\s]+(.*?)>/',
-						'<script crossorigin="anonymous" \1>',
+						'<script defer crossorigin="anonymous" \1>',
 						$revised_html
 					);
 				}


### PR DESCRIPTION
closes #126 

Other scripts being enqueued by `wp_enqueue_script` are already getting the `defer` attribute by default. For example, the `<script>` that gets added to the page when in "Use CDN" mode (versus "Use a Kit" mode) has `defer`, and this is not configurable.

So it seems out of place that we aren't already adding `defer` to the `<script>` in the "Use a Kit" mode. Thus, rather than making this optional or configurable, as suggested by the request in #126, it seems preferable to keep it simple, thinking of this more like a bug fix--achieving parity with the other `<script>` loading.

If it seems like a problem, we could add a filter. However we do that, then we might need to add different filters for different scripts since they currently already differ in the application of their defer attributes. In other words, since they don't all have the same values now, it may not work to have a single filter that sets them all to on or off.