### PR TITLE
Enable icon chooser on full site editor

### DIFF
--- a/docker/Dockerfile-latest
+++ b/docker/Dockerfile-latest
@@ -1,6 +1,11 @@
 FROM wordpress:latest
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+# Node installation
+# See: https://deb.nodesource.com/
+RUN apt-get update && apt-get install -y ca-certificates curl gnupg
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /tmp/nodesource.gpg
+ENV NODE_MAJOR=20
+RUN echo "deb [signed-by=/tmp/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Install packages
 RUN apt-get update && \

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -277,7 +277,7 @@ class FontAwesome {
 	 * @internal
 	 * @ignore
 	 */
-	protected $icon_chooser_screens = array( 'post.php', 'post-new.php' );
+	protected $icon_chooser_screens = array( 'post.php', 'post-new.php', 'site-editor.php' );
 
 	/**
 	 * @internal


### PR DESCRIPTION
closes #208 

This simple enables the the icon chooser when the page's screen id is `site-editor.php`.