### PR TITLE
Fetch svg styles on loading admin

### DIFF
--- a/includes/class-fontawesome-svg-styles-manager.php
+++ b/includes/class-fontawesome-svg-styles-manager.php
@@ -168,7 +168,7 @@ class FontAwesome_SVG_Styles_Manager {
 	 * @ignore
 	 * @return string
 	 */
-	public function selfhost_asset_full_path( $fa, $fa_release_provider ) {
+	public function selfhost_asset_full_path( $fa ) {
 		$options          = $fa->options();
 		$concrete_version = $fa->concrete_version( $options );
 
@@ -210,7 +210,7 @@ class FontAwesome_SVG_Styles_Manager {
 	 * @ignore
 	 * @return bool
 	 */
-	public function is_svg_stylesheet_present( $fa, $fa_release_provider ) {
+	public function is_svg_stylesheet_present( $fa ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			throw new SelfhostSetupException(
 				esc_html__(
@@ -220,7 +220,7 @@ class FontAwesome_SVG_Styles_Manager {
 			);
 		}
 
-		$asset_full_path = $this->selfhost_asset_full_path( $fa, $fa_release_provider );
+		$asset_full_path = $this->selfhost_asset_full_path( $fa );
 
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -265,7 +265,7 @@ class FontAwesome_SVG_Styles_Manager {
 			);
 		}
 
-		if ( $this->is_svg_stylesheet_present( $fa, $fa_release_provider ) ) {
+		if ( $this->is_svg_stylesheet_present( $fa ) ) {
 			// Nothing more to do.
 			return;
 		}

--- a/includes/class-fontawesome-svg-styles-manager.php
+++ b/includes/class-fontawesome-svg-styles-manager.php
@@ -153,6 +153,94 @@ class FontAwesome_SVG_Styles_Manager {
 	}
 
 	/**
+	 *
+	 * Internal use only, not part of the plugin's public API.
+	 *
+	 * Returns the full path to the SVG support stylesheet on the server's filesystem.
+	 *
+	 * @param $fa FontAwesome
+	 * @param $fa_release_provider FontAwesome_Release_Provider
+	 * @throws ReleaseMetadataMissingException
+	 * @throws ReleaseProviderStorageException
+	 * @throws SelfhostSetupException
+	 * @throws ConfigCorruptionException when called with an invalid configuration
+	 * @internal
+	 * @ignore
+	 * @return string
+	 */
+	public function selfhost_asset_full_path($fa, $fa_release_provider) {
+		$options          = $fa->options();
+		$concrete_version = $fa()->concrete_version( $options );
+
+		if ( ! $concrete_version ) {
+			throw new SelfhostSetupException(
+				esc_html__(
+					'Failed to determine Font Awesome version when setting up self-hosted assets.',
+					'font-awesome'
+				)
+			);
+		}
+
+		$asset_path = $this->selfhost_asset_path( $concrete_version );
+
+		if ( ! $asset_path || ! isset( $asset_path['dir'] ) || ! isset( $asset_path['file'] ) ) {
+			throw new SelfhostSetupException(
+				esc_html__(
+					'Failed to determine filesystem location for self-hosted asset. Please report this on the plugin support forum so it can be investigated.',
+					'font-awesome'
+				)
+			);
+		}
+
+		return trailingslashit( $asset_path['dir'] ) . $asset_path['file'];
+	}
+
+	/**
+	 * Internal use only, not part of the plugin's public API.
+	 *
+	 * This checks whether the SVG support stylesheet is present.
+	 *
+	 * @param $fa FontAwesome
+	 * @param $fa_release_provider FontAwesome_Release_Provider
+	 * @throws ReleaseMetadataMissingException
+	 * @throws ReleaseProviderStorageException
+	 * @throws SelfhostSetupException
+	 * @throws ConfigCorruptionException when called with an invalid configuration
+	 * @internal
+	 * @ignore
+	 * @return bool
+	 */
+	public function is_svg_stylesheet_present($fa, $fa_release_provider) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			throw new SelfhostSetupException(
+				esc_html__(
+					'Current user lacks permissions required to fetch Font Awesome SVG stylesheets for self-hosting. Try logging in as an admin user.',
+					'font-awesome'
+				)
+			);
+		}
+
+		$asset_full_path = $this->selfhost_asset_full_path($fa, $fa_release_provider);
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! WP_Filesystem( false ) ) {
+			throw new SelfhostSetupException(
+				esc_html__(
+					'Failed to initialize filesystem usage for creating self-hosted assets. Please report this on the plugin support forum so it can be investigated.',
+					'font-awesome'
+				)
+			);
+		}
+
+		global $wp_filesystem;
+
+		return $wp_filesystem->exists( $full_asset_path );
+	}
+
+	/**
 	 * Internal use only, not part of this plugin's public API.
 	 *
 	 * Fetches SVG support style asset(s) for self-hosting.
@@ -177,30 +265,12 @@ class FontAwesome_SVG_Styles_Manager {
 			);
 		}
 
-		$options          = $fa->options();
-		$concrete_version = fa()->concrete_version( $options );
-
-		if ( ! $concrete_version ) {
-			throw new SelfhostSetupException(
-				esc_html__(
-					'Failed to determine Font Awesome version when setting up self-hosted assets.',
-					'font-awesome'
-				)
-			);
+		if ( $this->is_svg_stylesheet_present( $fa, $fa_release_provider ) ) {
+			// Nothing more to do.
+			return;
 		}
 
-		$asset_path = $this->selfhost_asset_path( $concrete_version );
-
-		if ( ! $asset_path || ! isset( $asset_path['dir'] ) || ! isset( $asset_path['file'] ) ) {
-			throw new SelfhostSetupException(
-				esc_html__(
-					'Failed to determine filesystem location for self-hosted asset. Please report this on the plugin support forum so it can be investigated.',
-					'font-awesome'
-				)
-			);
-		}
-
-		$full_asset_path = trailingslashit( $asset_path['dir'] ) . $asset_path['file'];
+		$asset_full_path = $this->selfhost_asset_full_path($fa, $fa_release_provider);
 
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -216,11 +286,6 @@ class FontAwesome_SVG_Styles_Manager {
 		}
 
 		global $wp_filesystem;
-
-		if ( $wp_filesystem->exists( $full_asset_path ) ) {
-			// Nothing more to do.
-			return;
-		}
 
 		$resource = $fa_release_provider->get_svg_styles_resource( $concrete_version );
 

--- a/includes/class-fontawesome-svg-styles-manager.php
+++ b/includes/class-fontawesome-svg-styles-manager.php
@@ -168,7 +168,7 @@ class FontAwesome_SVG_Styles_Manager {
 	 * @ignore
 	 * @return string
 	 */
-	public function selfhost_asset_full_path($fa, $fa_release_provider) {
+	public function selfhost_asset_full_path( $fa, $fa_release_provider ) {
 		$options          = $fa->options();
 		$concrete_version = $fa->concrete_version( $options );
 
@@ -210,7 +210,7 @@ class FontAwesome_SVG_Styles_Manager {
 	 * @ignore
 	 * @return bool
 	 */
-	public function is_svg_stylesheet_present($fa, $fa_release_provider) {
+	public function is_svg_stylesheet_present( $fa, $fa_release_provider ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			throw new SelfhostSetupException(
 				esc_html__(
@@ -220,7 +220,7 @@ class FontAwesome_SVG_Styles_Manager {
 			);
 		}
 
-		$asset_full_path = $this->selfhost_asset_full_path($fa, $fa_release_provider);
+		$asset_full_path = $this->selfhost_asset_full_path( $fa, $fa_release_provider );
 
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/includes/class-fontawesome-svg-styles-manager.php
+++ b/includes/class-fontawesome-svg-styles-manager.php
@@ -170,7 +170,7 @@ class FontAwesome_SVG_Styles_Manager {
 	 */
 	public function selfhost_asset_full_path($fa, $fa_release_provider) {
 		$options          = $fa->options();
-		$concrete_version = $fa()->concrete_version( $options );
+		$concrete_version = $fa->concrete_version( $options );
 
 		if ( ! $concrete_version ) {
 			throw new SelfhostSetupException(
@@ -237,7 +237,7 @@ class FontAwesome_SVG_Styles_Manager {
 
 		global $wp_filesystem;
 
-		return $wp_filesystem->exists( $full_asset_path );
+		return $wp_filesystem->exists( $asset_full_path );
 	}
 
 	/**
@@ -270,7 +270,20 @@ class FontAwesome_SVG_Styles_Manager {
 			return;
 		}
 
-		$asset_full_path = $this->selfhost_asset_full_path($fa, $fa_release_provider);
+		$concrete_version = $fa->concrete_version( $fa->options() );
+
+		$asset_path = $this->selfhost_asset_path( $concrete_version );
+
+		if ( ! $asset_path || ! isset( $asset_path['dir'] ) || ! isset( $asset_path['file'] ) ) {
+			throw new SelfhostSetupException(
+				esc_html__(
+					'Failed to determine filesystem location for self-hosted asset. Please report this on the plugin support forum so it can be investigated.',
+					'font-awesome'
+				)
+			);
+		}
+
+		$full_asset_path = trailingslashit( $asset_path['dir'] ) . $asset_path['file'];
 
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1039,7 +1039,7 @@ class FontAwesome {
 
 		try {
 			$svg_styles_manager = FontAwesome_SVG_Styles_Manager::instance();
-			if ( ! $svg_styles_manager->is_svg_stylesheet_present( $this, $this->release_provider() ) ) {
+			if ( ! $svg_styles_manager->is_svg_stylesheet_present( $this ) ) {
 				$svg_styles_manager->fetch_svg_styles( $this, $this->release_provider() );
 			}
 		} catch ( Exception $e ) {

--- a/includes/class-fontawesome.php
+++ b/includes/class-fontawesome.php
@@ -1036,6 +1036,17 @@ class FontAwesome {
 			10,
 			3
 		);
+
+		try {
+			$svg_styles_manager = FontAwesome_SVG_Styles_Manager::instance();
+			if ( ! $svg_styles_manager->is_svg_stylesheet_present( $this, $this->release_provider() ) ) {
+				$svg_styles_manager->fetch_svg_styles( $this, $this->release_provider() );
+			}
+		} catch ( Exception $e ) {
+			notify_admin_fatal_error( $e );
+		} catch ( Error $e ) {
+			notify_admin_fatal_error( $e );
+		}
 	}
 
 	/**


### PR DESCRIPTION
When upgrading to 5x from 4x, the SVG support stylesheet is loaded unconditionally. Yet, in v5.0.0, it will not yet have been fetched when first upgrading. Not until some plugin settings have been changed, or the plugin is deactivated/re-activated.

This change checks for the presence of that stylesheet any time the plugin's admin init code is run, which is any time the WP admin dashboard is loaded after the plugin is upgraded.

It would therefore also run automatically when loading the plugin's settings page, or the block editor.