### PR TITLE
remove the version-based condition on the loading of SVG support stylesheet

### DIFF
--- a/includes/class-fontawesome-release-provider.php
+++ b/includes/class-fontawesome-release-provider.php
@@ -552,9 +552,7 @@ EOD;
 	 * @return FontAwesome_Resource
 	 */
 	public function get_svg_styles_resource( $version ) {
-		$file_basename = ( is_string( $version ) && strlen( $version ) > 0 && '7' === $version[0] )
-			? 'svg'
-			: 'svg-with-js';
+		$file_basename = 'svg-with-js';
 
 		$cdn_url_template = null;
 

--- a/includes/class-fontawesome-svg-styles-manager.php
+++ b/includes/class-fontawesome-svg-styles-manager.php
@@ -110,9 +110,7 @@ class FontAwesome_SVG_Styles_Manager {
 	 * @internal
 	 */
 	public static function selfhost_asset_filename( $version ) {
-		return ( is_string( $version ) && strlen( $version ) > 0 && '7' === $version[0] )
-			? 'svg.css'
-			: 'svg-with-js.css';
+		return 'svg-with-js.css';
 	}
 
 	/**

--- a/includes/class-fontawesome-svg-styles-manager.php
+++ b/includes/class-fontawesome-svg-styles-manager.php
@@ -109,7 +109,7 @@ class FontAwesome_SVG_Styles_Manager {
 	 * @ignore
 	 * @internal
 	 */
-	public static function selfhost_asset_filename( $version ) {
+	public static function selfhost_asset_filename() {
 		return 'svg-with-js.css';
 	}
 


### PR DESCRIPTION
closes #263 

This PR reverts a prior change to use `svg.css` when Font Awesome 7 is active. It takes us back to always using `svg-with-js.css`, which includes the animations CSS.

Upside: everything that's needed is available in `svg-with-js.css`

Downside: more than is needed is included in `svg-with-js.css`. It's about twice the size of `svg.css`. And some of that will be loaded twice, because the kit loader will load some of that same content, whether it's a webfont kit or SVG kit.

However, for now, it's better to load more than necessary and have all of the feature support, than to load `svg.css` to minimize the number of bytes loaded and break animations.