### PR TITLE
API requests use cache for service interruptions

### DIFF
--- a/includes/class-fontawesome-metadata-provider.php
+++ b/includes/class-fontawesome-metadata-provider.php
@@ -136,18 +136,33 @@ class FontAwesome_Metadata_Provider {
 			$args['headers']['authorization'] = "Bearer $access_token";
 		}
 
+		$cache_key = 'font-awesome-query-' . md5( $body . '|' . ( $ignore_auth ? '1' : '0' ) );
+
 		$response = $this->post( FONTAWESOME_API_URL, $args );
 
 		if ( $response instanceof WP_Error ) {
+			$exception = ApiRequestException::with_wp_error( add_failed_request_diagnostics( $response ) );
+			$stale     = get_transient( $cache_key );
+			if ( is_string( $stale ) ) {
+				notify_admin_warning( $exception );
+				return $stale;
+			}
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw ApiRequestException::with_wp_error( add_failed_request_diagnostics( $response ) );
+			throw $exception;
 		}
 
 		if ( 200 === $response['response']['code'] ) {
+			set_transient( $cache_key, $response['body'], MONTH_IN_SECONDS );
 			return $response['body'];
 		} else {
+			$exception = ApiResponseException::with_wp_response( $response );
+			$stale     = get_transient( $cache_key );
+			if ( is_string( $stale ) ) {
+				notify_admin_warning( $exception );
+				return $stale;
+			}
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw ApiResponseException::with_wp_response( $response );
+			throw $exception;
 		}
 	}
 }

--- a/tests/test-metadata-provider.php
+++ b/tests/test-metadata-provider.php
@@ -28,6 +28,36 @@ class MetadataProviderTest extends TestCase {
 		FontAwesome_Metadata_Provider::reset();
 		remove_all_filters( 'pre_http_request' );
 		remove_all_actions( 'font_awesome_preferences' );
+		self::clear_metadata_query_cache();
+	}
+
+	/**
+	 * Clears any stale-fallback transients written by metadata_query().
+	 * Transient keys are hashes of the request body, so we flush by prefix.
+	 */
+	protected static function clear_metadata_query_cache() {
+		global $wpdb;
+		$wpdb->query(
+			"DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_transient\\_font-awesome-query-%' OR option_name LIKE '\\_transient\\_timeout\\_font-awesome-query-%'"
+		);
+	}
+
+	/**
+	 * Mirrors the cache key construction in
+	 * FontAwesome_Metadata_Provider::metadata_query() so tests can pre-seed
+	 * and assert the stale-fallback cache.
+	 */
+	protected static function metadata_query_cache_key( $query, $ignore_auth = false ) {
+		if ( is_string( $query ) ) {
+			$body = '{"query": ' . wp_json_encode( $query ) . '}';
+		} else {
+			$filtered          = array( 'query' => $query['query'] );
+			if ( array_key_exists( 'variables', $query ) ) {
+				$filtered['variables'] = $query['variables'];
+			}
+			$body = wp_json_encode( $filtered );
+		}
+		return 'font-awesome-query-' . md5( $body . '|' . ( $ignore_auth ? '1' : '0' ) );
 	}
 
 	protected static function build_success_response() {
@@ -356,5 +386,74 @@ class MetadataProviderTest extends TestCase {
 		$result = fa_metadata_provider()->metadata_query( $query, true );
 
 		$this->assertTrue( is_string( $result ) );
+	}
+
+	public function test_metadata_query_writes_through_on_success() {
+		$query         = 'query { releases { version } }';
+		$mock_response = self::build_success_response();
+		$famp          = $this->create_metadata_provider_with_mocked_response( $mock_response );
+
+		$famp->metadata_query( $query, true );
+
+		$cached = get_transient( self::metadata_query_cache_key( $query, true ) );
+		$this->assertIsString( $cached );
+		$this->assertEquals( $mock_response['body'], $cached );
+	}
+
+	public function test_metadata_query_serves_stale_on_wp_error() {
+		$query     = 'query { releases { version } }';
+		$stale_body = '{"data":{"releases":[{"version":"1.2.3"}]}}';
+		set_transient( self::metadata_query_cache_key( $query, true ), $stale_body, MONTH_IN_SECONDS );
+
+		$famp = $this->create_metadata_provider_with_mocked_response( new WP_Error( 'fake error' ) );
+
+		$result = $famp->metadata_query( $query, true );
+
+		$this->assertEquals( $stale_body, $result );
+	}
+
+	public function test_metadata_query_serves_stale_on_500() {
+		$query     = 'query { releases { version } }';
+		$stale_body = '{"data":{"releases":[{"version":"9.9.9"}]}}';
+		set_transient( self::metadata_query_cache_key( $query, true ), $stale_body, MONTH_IN_SECONDS );
+
+		$famp = $this->create_metadata_provider_with_mocked_response( self::build_500_response() );
+
+		$result = $famp->metadata_query( $query, true );
+
+		$this->assertEquals( $stale_body, $result );
+	}
+
+	public function test_metadata_query_throws_when_no_cache_on_failure() {
+		// Cache cleared by set_up(). A fresh failure with no prior success should
+		// still surface the exception so first-time failures aren't silently swallowed.
+		$famp = $this->create_metadata_provider_with_mocked_response( self::build_500_response() );
+
+		$caught = false;
+		try {
+			$famp->metadata_query( 'query { releases { version } }', true );
+		} catch ( ApiResponseException $e ) {
+			$caught = true;
+		}
+		$this->assertTrue( $caught );
+	}
+
+	public function test_metadata_query_ignore_auth_uses_separate_cache_key() {
+		$query = 'query { releases { version } }';
+
+		$auth_body   = '{"data":{"releases":[{"version":"auth"}]}}';
+		$noauth_body = '{"data":{"releases":[{"version":"noauth"}]}}';
+
+		set_transient( self::metadata_query_cache_key( $query, false ), $auth_body, MONTH_IN_SECONDS );
+		set_transient( self::metadata_query_cache_key( $query, true ), $noauth_body, MONTH_IN_SECONDS );
+
+		$this->assertNotEquals(
+			self::metadata_query_cache_key( $query, false ),
+			self::metadata_query_cache_key( $query, true )
+		);
+
+		$famp = $this->create_metadata_provider_with_mocked_response( self::build_500_response() );
+
+		$this->assertEquals( $noauth_body, $famp->metadata_query( $query, true ) );
 	}
 }


### PR DESCRIPTION
A service disruption on api.fontawesome.com took down several sites that were using Beaver Builder where those sites were querying Kits.

```
PHP Fatal error: Uncaught FortAwesome\ApiResponseException: An unexpected response
  was received from the Font Awesome API server.
    in /nas/content/live/REDACTED/wp-content/plugins/font-awesome/includes/class-fontawesome-exception.php:68

  Stack trace:
   #0  font-awesome/includes/class-fontawesome-metadata-provider.php(150)
         FortAwesome\FontAwesome_Exception::with_wp_response(Array)
   #1  font-awesome/includes/class-fontawesome.php(2919)
         FortAwesome\FontAwesome_Metadata_Provider->metadata_query('{ me { kit(toke...')
   #2  bb-plugin/classes/class-fl-builder-font-awesome.php(261)
         FortAwesome\FontAwesome->query('{ me { kit(toke...')
   #3  bb-plugin/classes/class-fl-builder-icons.php(243)
         FLBuilderFontAwesome::get_kit_data()
   #4  bb-plugin/classes/class-fl-builder-icons.php(46)
         FLBuilderIcons::register_custom_sets()
   #5  bb-plugin/classes/class-fl-builder-icons.php(505)
         FLBuilderIcons::get_sets()
   #6  bb-plugin/classes/class-fl-builder-icons.php(454)
         FLBuilderIcons::enqueue_styles_for_icon('', Array, Object(stdClass))
   #7  bb-plugin/classes/class-fl-builder-icons.php(425)
         FLBuilderIcons::enqueue_styles_for_nested_module_form(
             Object(FLContentSliderModule), Array, 'slides')
   #8  bb-plugin/classes/class-fl-builder-module.php(399)
         FLBuilderModule->enqueue_icon_styles()
   #9  bb-plugin/classes/class-fl-builder.php(638)
         FLBuilder::enqueue_module_layout_styles_scripts(Object(FLContentSliderModule))
   #10 bb-plugin/classes/class-fl-builder.php(616)
         FLBuilder::enqueue_layout_styles_scripts()
   #11 bb-plugin/classes/class-fl-builder.php(535)
         FLBuilder::enqueue_all_layouts_styles_scripts('')
   #12 wp-includes/class-wp-hook.php(341)
         WP_Hook->apply_filters(NULL, Array)
   #13 wp-includes/class-wp-hook.php(365)
         WP_Hook->do_action(Array)
   #14 wp-includes/plugin.php(522)
         do_action('wp_enqueue_scri...')
   #15 wp-includes/script-loader.php(2311)
         wp_enqueue_scripts('')
   #16 wp-includes/class-wp-hook.php(341)
         WP_Hook->apply_filters(NULL, Array)
   #17 wp-includes/class-wp-hook.php(365)
         WP_Hook->do_action(Array)
   #18 wp-includes/plugin.php(522)
         do_action('wp_head')
   #19 wp-includes/general-template.php(3197)
         wp_head()
   #20 themes/bb-theme/header.php(11)
         require_once('...')
   #21 wp-includes/template.php(814)
         load_template('...', true, Array)
   #22 wp-includes/template.php(749)
         locate_template(Array, true, true, Array)
   #23 wp-includes/general-template.php(48)
         get_header()
   #24 themes/bb-theme/page.php(1)
         include('...')
   #25 wp-includes/template-loader.php(132)
         require_once('...')
   #26 wp-blog-header.php(19)
         require('...')
   #27 index.php(17)
         {main}

  thrown in font-awesome/includes/class-fontawesome-exception.php on line 68

```

@mlwilkerson I think a better fix for this might be to chat with BB and let them control the behavior but this PR adds a "use cache on origin error" pattern that provides some insurance.

What do you think about this idea?